### PR TITLE
Add comma between tidyselect and utils in DESCRIPTION.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,7 +19,7 @@ Imports:
     rstudioapi,
     shiny,
     tidyr,
-    tidyselect
+    tidyselect,
     utils
 Encoding: UTF-8
 LazyData: true


### PR DESCRIPTION
The DESCRIPTION file needed a comma between `tidyselect` and `utils` as indicated by trying to install the package:

```
Downloading GitHub repo neo4j-rstats/neo4r@master
from URL https://api.github.com/repos/neo4j-rstats/neo4r/zipball/master
Installing neo4r
'/usr/lib/R/bin/R' --no-site-file --no-environ --no-save --no-restore --quiet  \
  CMD INSTALL  \
  '/tmp/RtmpLxOyMb/devtools631d1b4d42ef/neo4j-rstats-neo4r-c9294dd'  \
  --library='/home/garrett/R/rlibs' --install-tests 

* installing *source* package ‘neo4r’ ...
Error : Invalid DESCRIPTION file

Malformed Depends or Suggests or Imports or Enhances field.
Offending entries:
  tidyselect
utils
Entries must be names of packages optionally followed by '<=' or '>=',
white space, and a valid version number in parentheses.

See section 'The DESCRIPTION file' in the 'Writing R Extensions'
manual.

ERROR: installing package DESCRIPTION failed for package ‘neo4r’
* removing ‘/home/garrett/R/rlibs/neo4r’
* restoring previous ‘/home/garrett/R/rlibs/neo4r’
Installation failed: Command failed (1)
```